### PR TITLE
pi_counter.rb: Compare masked values to zero.

### DIFF
--- a/pi_counter.rb
+++ b/pi_counter.rb
@@ -17,10 +17,10 @@ PiPiper.watch :pin => 22, :trigger => :rising do |pin|
   puts sum
 
   # get single bits of sum
-  pin4.update_value(sum & 0b0001 == 0b0001)
-  pin5.update_value(sum & 0b0010 == 0b0010)
-  pin17.update_value(sum & 0b0100 == 0b0100)
-  pin27.update_value(sum & 0b1000 == 0b1000)
+  pin4.update_value(sum & 0b0001 != 0)
+  pin5.update_value(sum & 0b0010 != 0)
+  pin17.update_value(sum & 0b0100 != 0)
+  pin27.update_value(sum & 0b1000 != 0)
 end
 
 PiPiper.wait


### PR DESCRIPTION
This is a minor refactoring.

Comparing masked values to zero is preferred over comparing them
to the mask. There is less to read, so it is easier to read. It's
easy to mess up typing mask values on the right side of the ==,
so comparing to zeros is less prone to editing errors. Comparing
to zero is usually also faster, because most CPUs already know if
a result is zero or not.

By the way, regardless of whether one compares to zero or the
mask, your expressions are valid in Ruby because in Ruby the &
operator has higher precedence than the == operator.

C is popular for embedded software. Never minding the binary
constants, if you were to try your expressions in C, they would
probably not work as you would want because the & operator has
lower precedence than the == operator in C. That has bit many
many C programmers. In C the following would work.

```
(sum & mask) == mask
(sum & mask) != 0
!!(sum & mask)
```

How would you translate the following Python code to Ruby?

```
for i, pin in enumerate([pin4, pin5, pin17, pin27]):
    mask = 1<<i
    pin.update_value((sum & mask) != 0)
```
